### PR TITLE
Feature UGN-240 upload step example table

### DIFF
--- a/src/components/Table.tsx
+++ b/src/components/Table.tsx
@@ -32,7 +32,12 @@ const createGlobalStyleOverride = () => css`
   .rdg-static {
     cursor: pointer;
   }
-
+  
+  .rdg-example .rdg-cell {
+    --rdg-selection-color: none;
+    border-bottom: none;
+  }
+  
   .rdg-static .rdg-cell {
     --rdg-selection-color: none;
   }

--- a/src/steps/UploadStep/UploadStep.tsx
+++ b/src/steps/UploadStep/UploadStep.tsx
@@ -2,17 +2,20 @@ import type XLSX from "xlsx"
 import { Box, Heading, Text } from "@chakra-ui/react"
 import { DropZone } from "./components/DropZone"
 import { useRsi } from "../../hooks/useRsi"
+import { ExampleTable } from "./components/ExampleTable"
+import React from "react"
+import { FadingOverlay } from "./components/FadingOverlay"
 
 const DEFAULT_TITLE = "Upload Sheet"
 const MANIFEST_TITLE = "Data that we expect:"
-const MANIFEST_DESCRIPTION = "(You will have a chance to select and rename columns in next steps)"
+const MANIFEST_DESCRIPTION = "(You will have a chance to rename or remove columns in next steps)"
 
 type UploadProps = {
   onContinue: (data: XLSX.WorkBook) => void
 }
 
 export const UploadStep = ({ onContinue }: UploadProps) => {
-  const { title } = useRsi()
+  const { title, fields } = useRsi()
   return (
     <Box minH="fit-content" display="flex" flex={1} p="2rem" flexDirection="column">
       <Heading size="lg" color="gray.700" mb="2rem">
@@ -21,9 +24,13 @@ export const UploadStep = ({ onContinue }: UploadProps) => {
       <Text fontSize="2xl" lineHeight={8} fontWeight="semibold" color="gray.700">
         {MANIFEST_TITLE}
       </Text>
-      <Text fontSize="md" lineHeight={6} color="gray.500" mb="2rem">
+      <Text fontSize="md" lineHeight={6} color="gray.500" mb="1rem">
         {MANIFEST_DESCRIPTION}
       </Text>
+      <Box mb="0.5rem" position="relative">
+        <ExampleTable fields={fields} />
+        <FadingOverlay />
+      </Box>
       <DropZone onContinue={onContinue} />
     </Box>
   )

--- a/src/steps/UploadStep/components/ExampleTable.tsx
+++ b/src/steps/UploadStep/components/ExampleTable.tsx
@@ -1,0 +1,16 @@
+import type { Fields, InitHook, RowHook, TableHook } from "../../../types"
+import { useMemo, useState } from "react"
+import { Table } from "../../../components/Table"
+import { generateColumns } from "./columns"
+import { generateExampleRow } from "../utils/generateExampleRow"
+
+interface Props<T> {
+  fields: Fields<T>
+}
+
+export const ExampleTable = <T,>({ fields }: Props<T>) => {
+  const data = useMemo(() => generateExampleRow(fields), [])
+  const columns = useMemo(() => generateColumns(fields), [])
+
+  return <Table rows={data} columns={columns} className={'rdg-example'}/>
+}

--- a/src/steps/UploadStep/components/FadingOverlay.tsx
+++ b/src/steps/UploadStep/components/FadingOverlay.tsx
@@ -1,0 +1,14 @@
+import { Box } from "@chakra-ui/react"
+import React from "react"
+
+export const FadingOverlay = () => (
+  <Box
+    position="absolute"
+    left={0}
+    right={0}
+    bottom={0}
+    height="48px"
+    pointerEvents="none"
+    bg="linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 1))"
+  />
+)

--- a/src/steps/UploadStep/components/columns.tsx
+++ b/src/steps/UploadStep/components/columns.tsx
@@ -1,0 +1,17 @@
+import type { Column } from "react-data-grid"
+import { Box } from "@chakra-ui/react"
+import type { Field, Fields } from "../../../types"
+
+export const generateColumns = <T,>(fields: Fields<T>) =>
+  fields.map(
+    (column: Field<T>): Column<any> => ({
+      key: column.key,
+      name: column.label,
+      resizable: true,
+      formatter: ({ row }) => (
+        <Box minWidth="100%" minHeight="100%" overflow="hidden" textOverflow="ellipsis">
+          {row[column.key]}
+        </Box>
+      ),
+    }),
+  )

--- a/src/steps/UploadStep/utils/generateExampleRow.ts
+++ b/src/steps/UploadStep/utils/generateExampleRow.ts
@@ -1,0 +1,14 @@
+import type { Field, Fields } from "../../../types"
+
+const titleMap: Record<Field<any>["fieldType"]["type"], string> = {
+  checkbox: "Boolean",
+  select: "Options",
+  input: "Text",
+}
+
+export const generateExampleRow = <T>(fields: Fields<T>) => [
+  fields.reduce((acc, field) => {
+    acc[field.key] = field.example || titleMap[field.fieldType.type]
+    return acc
+  }, {} as Record<Extract<keyof T, string>, string>),
+]

--- a/src/stories/mockRsiValues.ts
+++ b/src/stories/mockRsiValues.ts
@@ -8,7 +8,7 @@ const fields: Field<any>[] = [
     fieldType: {
       type: "input",
     },
-    examples: ["Teddy", "John", "Stephanie"],
+    example: "Stephanie",
   },
   {
     label: "Surname",
@@ -17,7 +17,7 @@ const fields: Field<any>[] = [
     fieldType: {
       type: "input",
     },
-    examples: ["McDonald", "Smith", "Chomsky"],
+    example: "McDonald",
   },
   {
     label: "Age",
@@ -26,7 +26,7 @@ const fields: Field<any>[] = [
     fieldType: {
       type: "input",
     },
-    examples: ["23", "77", "99"],
+    example: "23",
   },
 ]
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -44,7 +44,7 @@ export type Field<T> = {
   // Field entry component, default: Input
   fieldType: Checkbox | Select | Input
   // UI-facing values shown to user as field examples pre-upload phase
-  examples?: string[]
+  example?: string
 }
 
 export type Checkbox = {


### PR DESCRIPTION
  - Added example table - row is generated from example in config
  - changed `examples: string[]` to `example: string` because only one example row is displayed
<img width="1171" alt="Screenshot 2022-02-23 at 17 37 38" src="https://user-images.githubusercontent.com/5903616/155353952-967d2cc6-69a2-423c-9224-bea1e77b0dec.png">
