### PR TITLE
Feature UGN-241 tooltips in tables that show descriptions

### DIFF
--- a/src/steps/UploadStep/components/columns.tsx
+++ b/src/steps/UploadStep/components/columns.tsx
@@ -1,6 +1,7 @@
 import type { Column } from "react-data-grid"
-import { Box } from "@chakra-ui/react"
+import { Box, Tooltip } from "@chakra-ui/react"
 import type { Field, Fields } from "../../../types"
+import { CgInfo } from "react-icons/cg"
 
 export const generateColumns = <T,>(fields: Fields<T>) =>
   fields.map(
@@ -8,6 +9,18 @@ export const generateColumns = <T,>(fields: Fields<T>) =>
       key: column.key,
       name: column.label,
       resizable: true,
+      headerRenderer: () => (
+        <Box display="flex" gap={1} alignItems="center" position="relative">
+          {column.label}
+          {column.description && (
+            <Tooltip placement="top" hasArrow label={column.description}>
+              <span>
+                <CgInfo size="1rem" />
+              </span>
+            </Tooltip>
+          )}
+        </Box>
+      ),
       formatter: ({ row }) => (
         <Box minWidth="100%" minHeight="100%" overflow="hidden" textOverflow="ellipsis">
           {row[column.key]}

--- a/src/steps/ValidationStep/components/columns.tsx
+++ b/src/steps/ValidationStep/components/columns.tsx
@@ -3,6 +3,7 @@ import { Box, Checkbox, Input, Select, Switch, Tooltip } from "@chakra-ui/react"
 import type { Field, Fields } from "../../../types"
 import type { ChangeEvent } from "react"
 import type { Data, Meta } from "../types"
+import { CgInfo } from "react-icons/cg"
 
 const SELECT_COLUMN_KEY = "select-row"
 
@@ -44,6 +45,18 @@ export const generateColumns = <T,>(fields: Fields<T>) => [
       key: column.key,
       name: column.label,
       resizable: true,
+      headerRenderer: () => (
+        <Box display="flex" gap={1} alignItems="center" position="relative">
+          {column.label}
+          {column.description && (
+            <Tooltip placement="top" hasArrow label={column.description}>
+              <span>
+                <CgInfo size="1rem" />
+              </span>
+            </Tooltip>
+          )}
+        </Box>
+      ),
       editable: column.fieldType.type !== "checkbox",
       editor: ({ row, onRowChange, onClose }) =>
         column.fieldType.type === "select" ? (

--- a/src/stories/mockRsiValues.ts
+++ b/src/stories/mockRsiValues.ts
@@ -25,6 +25,7 @@ const fields: Field<any>[] = [
         level: "info",
       },
     ],
+    description: 'Family / Last name',
   },
   {
     label: "Age",


### PR DESCRIPTION
  - added custom table header that displays icon with tooltip
<img width="406" alt="Screenshot 2022-02-28 at 17 10 17" src="https://user-images.githubusercontent.com/5903616/156007414-ed96344e-2411-445f-a462-1ff7096ec989.png">
<img width="473" alt="Screenshot 2022-02-28 at 17 09 43" src="https://user-images.githubusercontent.com/5903616/156007420-14a3e37a-4db8-4400-a50d-15d15cd9d9ae.png">
l