### PR TITLE
feat UGN-250 - added booleanMatches prop

### DIFF
--- a/src/steps/MatchColumnsStep/MatchColumnsStep.tsx
+++ b/src/steps/MatchColumnsStep/MatchColumnsStep.tsx
@@ -11,7 +11,7 @@ import type { Field } from "../../types"
 import { getMatchedColumns } from "./utils/getMatchedColumns"
 
 export type MatchColumnsProps = {
-  data: (string | number)[][]
+  data: string[][]
   headerValues: string[]
   onContinue: (data: any[]) => void
 }
@@ -20,18 +20,20 @@ export enum ColumnType {
   empty,
   ignored,
   matched,
+  matchedCheckbox,
   matchedSelect,
   matchedSelectOptions,
 }
 
 export type MatchedOptions<T> = {
-  entry: string | number
+  entry: string
   value: T
 }
 
 type EmptyColumn = { type: ColumnType.empty; index: number; header: string }
 type IgnoredColumn = { type: ColumnType.ignored; index: number; header: string }
 type MatchedColumn<T> = { type: ColumnType.matched; index: number; header: string; value: T }
+type MatchedSwitchColumn<T> = { type: ColumnType.matchedCheckbox; index: number; header: string; value: T }
 export type MatchedSelectColumn<T> = {
   type: ColumnType.matchedSelect
   index: number
@@ -51,6 +53,7 @@ export type Column<T extends string> =
   | EmptyColumn
   | IgnoredColumn
   | MatchedColumn<T>
+  | MatchedSwitchColumn<T>
   | MatchedSelectColumn<T>
   | MatchedSelectOptionsColumn<T>
 
@@ -107,7 +110,7 @@ export const MatchColumnsStep = <T extends string>({ data, headerValues, onConti
   return (
     <ColumnGrid
       columns={columns}
-      onContinue={() => onContinue(normalizeTableData(columns, data))}
+      onContinue={() => onContinue(normalizeTableData(columns, data, fields))}
       userColumn={(column) => (
         <UserTableColumn
           column={column}

--- a/src/steps/MatchColumnsStep/components/TemplateColumn.tsx
+++ b/src/steps/MatchColumnsStep/components/TemplateColumn.tsx
@@ -15,23 +15,28 @@ import { ColumnType } from "../MatchColumnsStep"
 import { MatchIcon } from "./MatchIcon"
 import { getFieldOptions } from "../utils/getFieldOptions"
 import type { Fields } from "../../../types"
-import type {TranslationsRSIProps, Translations} from "../../../translationsRSIProps"
+import type { Translations } from "../../../translationsRSIProps"
 
 const getAccordionTitle = <T extends string>(fields: Fields<T>, column: Column<T>, translations: Translations) => {
   const fieldLabel = fields.find((field) => "value" in column && field.key === column.value)!.label
-  return `${translations.matchColumnsStep.matchDropdownTitle} ${fieldLabel} (${"matchedOptions" in column && column.matchedOptions.length} ${translations.matchColumnsStep.unmatched})`
+  return `${translations.matchColumnsStep.matchDropdownTitle} ${fieldLabel} (${
+    "matchedOptions" in column && column.matchedOptions.length
+  } ${translations.matchColumnsStep.unmatched})`
 }
 
 type TemplateColumnProps<T extends string> = {
   onChange: (val: T, index: number) => void
-  onSubChange: (val: T, index: number, option: string | number) => void
+  onSubChange: (val: T, index: number, option: string) => void
   column: Column<T>
 }
 
 export const TemplateColumn = <T extends string>({ column, onChange, onSubChange }: TemplateColumnProps<T>) => {
   const { translations, fields } = useRsi<T>()
   const isIgnored = column.type === ColumnType.ignored
-  const isChecked = column.type === ColumnType.matched || column.type === ColumnType.matchedSelectOptions
+  const isChecked =
+    column.type === ColumnType.matched ||
+    column.type === ColumnType.matchedCheckbox ||
+    column.type === ColumnType.matchedSelectOptions
   const isSelect = "matchedOptions" in column
 
   return (

--- a/src/steps/MatchColumnsStep/components/UserTableColumn.tsx
+++ b/src/steps/MatchColumnsStep/components/UserTableColumn.tsx
@@ -5,7 +5,7 @@ import { ColumnType } from "../MatchColumnsStep"
 
 type UserTableColumnProps<T extends string> = {
   column: Column<T>
-  entries: (string | number)[]
+  entries: string[]
   onIgnore: (index: number) => void
   onRevertIgnore: (index: number) => void
 }
@@ -41,8 +41,8 @@ export const UserTableColumn = <T extends string>({
           />
         )}
       </Flex>
-      {entries.map((entry) => (
-        <Text fontSize="sm" lineHeight={5} fontWeight="medium" px={6} py={4} key={entry} color={textColor}>
+      {entries.map((entry, index) => (
+        <Text fontSize="sm" lineHeight={5} fontWeight="medium" px={6} py={4} key={entry + index} color={textColor}>
           {entry}
         </Text>
       ))}

--- a/src/steps/MatchColumnsStep/stories/MatchColumns.stories.tsx
+++ b/src/steps/MatchColumnsStep/stories/MatchColumns.stories.tsx
@@ -13,15 +13,15 @@ export default {
 
 const mockData = [
   ["id", "first_name", "last_name", "email", "gender", "ip_address"],
-  [2, "Geno", "Gencke", "ggencke0@tinypic.com", "Female", "17.204.180.40"],
-  [3, "Bertram", "Twyford", "btwyford1@seattletimes.com", "Genderqueer", "188.98.2.13"],
-  [4, "Tersina", "Isacke", "tisacke2@edublogs.org", "Non-binary", "237.69.180.31"],
-  [5, "Yoko", "Guilliland", "yguilliland3@elegantthemes.com", "Male", "179.123.237.119"],
-  [6, "Freida", "Fearns", "ffearns4@fotki.com", "Male", "184.48.15.1"],
-  [7, "Mildrid", "Mount", "mmount5@last.fm", "Male", "26.97.160.103"],
-  [8, "Jolene", "Darlington", "jdarlington6@jalbum.net", "Agender", "172.14.232.84"],
-  [9, "Craig", "Dickie", "cdickie7@virginia.edu", "Male", "143.248.220.47"],
-  [10, "Jere", "Shier", "jshier8@comcast.net", "Agender", "10.143.62.161"],
+  ["2", "Geno", "Gencke", "ggencke0@tinypic.com", "Female", "17.204.180.40"],
+  ["3", "Bertram", "Twyford", "btwyford1@seattletimes.com", "Genderqueer", "188.98.2.13"],
+  ["4", "Tersina", "Isacke", "tisacke2@edublogs.org", "Non-binary", "237.69.180.31"],
+  ["5", "Yoko", "Guilliland", "yguilliland3@elegantthemes.com", "Male", "179.123.237.119"],
+  ["6", "Freida", "Fearns", "ffearns4@fotki.com", "Male", "184.48.15.1"],
+  ["7", "Mildrid", "Mount", "mmount5@last.fm", "Male", "26.97.160.103"],
+  ["8", "Jolene", "Darlington", "jdarlington6@jalbum.net", "Agender", "172.14.232.84"],
+  ["9", "Craig", "Dickie", "cdickie7@virginia.edu", "Male", "143.248.220.47"],
+  ["10", "Jere", "Shier", "jshier8@comcast.net", "Agender", "10.143.62.161"],
 ]
 
 export const Basic = () => (

--- a/src/steps/MatchColumnsStep/utils/normalizeCheckboxValue.ts
+++ b/src/steps/MatchColumnsStep/utils/normalizeCheckboxValue.ts
@@ -1,0 +1,13 @@
+const booleanWhitelist: Record<string, boolean> = {
+  yes: true,
+  no: false,
+  true: true,
+  false: false,
+}
+
+export const normalizeCheckboxValue = (value: string | undefined): boolean => {
+  if (value && value.toLowerCase() in booleanWhitelist) {
+    return booleanWhitelist[value.toLowerCase()]
+  }
+  return false
+}

--- a/src/steps/MatchColumnsStep/utils/normalizeTableData.ts
+++ b/src/steps/MatchColumnsStep/utils/normalizeTableData.ts
@@ -1,12 +1,26 @@
 import type { Columns } from "../MatchColumnsStep"
 import { ColumnType } from "../MatchColumnsStep"
-import type { Data } from "../../../types"
+import type { Data, Fields } from "../../../types"
+import { normalizeCheckboxValue } from "./normalizeCheckboxValue"
 
-export const normalizeTableData = <T extends string>(columns: Columns<T>, data: (string | number)[][]) =>
+export const normalizeTableData = <T extends string>(columns: Columns<T>, data: string[][], fields: Fields<T>) =>
   data.map((row) =>
     row.reduce((acc, curr, index) => {
       const column = columns[index]
       switch (column.type) {
+        case ColumnType.matchedCheckbox: {
+          const field = fields.find((field) => field.key === column.value)!
+          if ("booleanMatches" in field.fieldType && Object.keys(field.fieldType).length) {
+            const booleanMatchKey = Object.keys(field.fieldType.booleanMatches || []).find(
+              (key) => key.toLowerCase() === curr.toLowerCase(),
+            )!
+            const booleanMatch = field.fieldType.booleanMatches?.[booleanMatchKey]
+            acc[column.value] = booleanMatchKey ? booleanMatch : normalizeCheckboxValue(curr)
+          } else {
+            acc[column.value] = normalizeCheckboxValue(curr)
+          }
+          return acc
+        }
         case ColumnType.matched: {
           acc[column.value] = curr === "" ? undefined : curr
           return acc

--- a/src/steps/MatchColumnsStep/utils/setColumn.ts
+++ b/src/steps/MatchColumnsStep/utils/setColumn.ts
@@ -16,6 +16,7 @@ export const setColumn = <T extends string>(
         matchedOptions: uniqueEntries(data || [], oldColumn.index),
       }
     case "checkbox":
+      return { index: oldColumn.index, type: ColumnType.matchedCheckbox, value: field.key, header: oldColumn.header }
     case "input":
       return { index: oldColumn.index, type: ColumnType.matched, value: field.key, header: oldColumn.header }
     default:

--- a/src/stories/mockRsiValues.ts
+++ b/src/stories/mockRsiValues.ts
@@ -70,6 +70,7 @@ const fields = [
     alternateMatches: ["manages"],
     fieldType: {
       type: "checkbox",
+      booleanMatches: {},
     },
     example: "true",
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,8 +55,8 @@ export type Field<T extends string> = {
 
 export type Checkbox = {
   type: "checkbox"
-  // Alternate values to be treated as booleans, e.g. 'yes'-> true, 'no' -> false
-  booleanMatches?: { [key: string]: boolean }[]
+  // Alternate values to be treated as booleans, e.g. {yes: true, no: false}
+  booleanMatches?: { [key: string]: boolean }
 }
 
 export type Select = {
@@ -69,7 +69,7 @@ export type SelectOptions = {
   // UI-facing option label
   label: string
   // Field entry matching criteria as well as select output
-  value: string | number
+  value: string
 }
 
 export type Input = {

--- a/src/utils/mapWorkbook.ts
+++ b/src/utils/mapWorkbook.ts
@@ -5,6 +5,7 @@ export const mapWorkbook = (workbook: XLSX.WorkBook, sheetName?: string) => {
   const data = XLSX.utils.sheet_to_json(worksheet, {
     header: 1,
     blankrows: false,
+    raw: false,
   })
   return data as string[][]
 }


### PR DESCRIPTION
- added alternate boolean matches via booleanMatches prop
- added whitelist of alternative boolean values like 'yes', 'no'
- configured sheetJs to use `raw: false` - this way all imported data remain strings and aren't converted to numbers and booleans. 
- all non boolean-looking strings matched with `checkbox` column will now have `false` default value

![Screenshot 2022-03-09 at 16 31 11](https://user-images.githubusercontent.com/45755753/157463134-b2245b01-b74e-48e0-b77a-0eafc7cb4623.png)
