### PR TITLE
After rows are deleted, reset data indexes

### DIFF
--- a/src/steps/ValidationStep/ValidationStep.tsx
+++ b/src/steps/ValidationStep/ValidationStep.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Heading, ModalBody, Switch, Text, useStyleConfig } from "@
 import { ContinueButton } from "../../components/ContinueButton"
 import { useRsi } from "../../hooks/useRsi"
 import type { Meta } from "./types"
-import { addErrorsAndRunHooks, addIndexes } from "./utils/dataMutations"
+import { addErrorsAndRunHooks, addIndexes, resetIndexes } from "./utils/dataMutations"
 import { generateColumns } from "./components/columns"
 import { Table } from "../../components/Table"
 import { SubmitDataAlert } from "../../components/Alerts/SubmitDataAlert"
@@ -36,7 +36,7 @@ export const ValidationStep = <T extends string>({ initialData }: Props<T>) => {
   const deleteSelectedRows = () => {
     if (selectedRows.size) {
       const newData = data.filter((value) => !selectedRows.has(value.__index))
-      updateData(newData)
+      updateData(resetIndexes<T>(newData))
       setSelectedRows(new Set())
     }
   }

--- a/src/steps/ValidationStep/utils/dataMutations.ts
+++ b/src/steps/ValidationStep/utils/dataMutations.ts
@@ -95,3 +95,8 @@ export const addIndexes = <T extends string>(arr: Data<T>[]): (Data<T> & { __ind
     }
     return { ...value, __index: index }
   })
+
+export const resetIndexes = <T extends string>(arr: Data<T>[]): (Data<T> & { __index: number })[] =>
+  arr.map((value, index) => {
+    return { ...value, __index: index }
+  })


### PR DESCRIPTION
This fixes a bug where updating rows after deletion causes the incorrect index to get updated.

Fixes https://github.com/UgnisSoftware/react-spreadsheet-import/issues/84, but no tests currently. I did some cursory tests in my own installation of RSI, and the data ends up correctly.