### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@emotion/styled": "^11.8.1",
     "chakra-react-select": "^3.1.2",
     "chakra-ui-steps": "^1.7.2",
-    "framer-motion": "^6.3.0",
+    "framer-motion": "4.1.17",
     "js-levenshtein": "^1.1.6",
     "lodash": "^4.17.21",
     "react": "^17.0.2",


### PR DESCRIPTION
Error with version of framer-motion : Can't import the named export 'Children' from non EcmaScript module (only default export is available)