### PR TITLE
Fix - Firefox not showing modal tables

### DIFF
--- a/src/steps/SelectHeaderStep/SelectHeaderStep.tsx
+++ b/src/steps/SelectHeaderStep/SelectHeaderStep.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from "react"
-import { Heading, ModalBody, useStyleConfig } from "@chakra-ui/react"
+import { Heading, ModalBody, useStyleConfig, Box } from "@chakra-ui/react"
 import { SelectHeaderTable } from "./components/SelectHeaderTable"
 import { ContinueButton } from "../../components/ContinueButton"
 import { useRsi } from "../../hooks/useRsi"
@@ -32,7 +32,9 @@ export const SelectHeaderStep = ({ data, onContinue }: SelectHeaderProps) => {
     <>
       <ModalBody pb={0}>
         <Heading {...styles.heading}>{translations.selectHeaderStep.title}</Heading>
-        <SelectHeaderTable data={data} selectedRows={selectedRows} setSelectedRows={setSelectedRows} />
+        <Box h={0} flexGrow={1}>
+          <SelectHeaderTable data={data} selectedRows={selectedRows} setSelectedRows={setSelectedRows} />
+        </Box>
       </ModalBody>
       <ContinueButton
         onContinue={handleContinue}

--- a/src/steps/ValidationStep/ValidationStep.tsx
+++ b/src/steps/ValidationStep/ValidationStep.tsx
@@ -129,23 +129,25 @@ export const ValidationStep = <T extends string>({ initialData }: Props<T>) => {
             </Switch>
           </Box>
         </Box>
-        <Table
-          rowKeyGetter={rowKeyGetter}
-          rows={tableData}
-          onRowsChange={updateRow}
-          columns={columns}
-          selectedRows={selectedRows}
-          onSelectedRowsChange={setSelectedRows}
-          components={{
-            noRowsFallback: (
-              <Box display="flex" justifyContent="center" gridColumn="1/-1" mt="32px">
-                {filterByErrors
-                  ? translations.validationStep.noRowsMessageWhenFiltered
-                  : translations.validationStep.noRowsMessage}
-              </Box>
-            ),
-          }}
-        />
+        <Box h={0} flexGrow={1}>
+          <Table
+            rowKeyGetter={rowKeyGetter}
+            rows={tableData}
+            onRowsChange={updateRow}
+            columns={columns}
+            selectedRows={selectedRows}
+            onSelectedRowsChange={setSelectedRows}
+            components={{
+              noRowsFallback: (
+                <Box display="flex" justifyContent="center" gridColumn="1/-1" mt="32px">
+                  {filterByErrors
+                    ? translations.validationStep.noRowsMessageWhenFiltered
+                    : translations.validationStep.noRowsMessage}
+                </Box>
+              ),
+            }}
+          />
+        </Box>
       </ModalBody>
       <ContinueButton onContinue={onContinue} title={translations.validationStep.nextButtonTitle} />
     </>


### PR DESCRIPTION
When using Firefox, the header selection and validation steps are showing as blank due to an issue with FF rendering divs of `display:grid` and padding/margin.

Tested to work on both FF and Chrome.