### PR TITLE
Allow regex validations to match empty fields

### DIFF
--- a/src/steps/ValidationStep/utils/dataMutations.ts
+++ b/src/steps/ValidationStep/utils/dataMutations.ts
@@ -60,7 +60,8 @@ export const addErrorsAndRunHooks = <T extends string>(
         case "regex": {
           const regex = new RegExp(validation.value, validation.flags)
           data.forEach((entry, index) => {
-            if (!entry[field.key]?.toString()?.match(regex)) {
+            const value = entry[field.key]?.toString() ?? ""
+            if (!value.match(regex)) {
               errors[index] = {
                 ...errors[index],
                 [field.key]: {


### PR DESCRIPTION
Take these example field validations:
```ts
      validations: [
        {
          rule: 'regex',
          value: '^.{0,10}$',
          errorMessage: 'Name too long',
        },
      ],
```
This error will show up for empty cells if they have not been edited. After they have been edited the empty string is stored, and the match will succeed.

This PR fixes this by defaulting the cell value to an empty string.