### PR TITLE
Improvements for unique field validations

### DIFF
--- a/src/steps/ValidationStep/utils/dataMutations.ts
+++ b/src/steps/ValidationStep/utils/dataMutations.ts
@@ -30,8 +30,20 @@ export const addErrorsAndRunHooks = <T extends string>(
       switch (validation.rule) {
         case "unique": {
           const values = data.map((entry) => entry[field.key as T])
+
+          const taken = new Set() // Set of items used at least once
+          const duplicates = new Set() // Set of items used multiple times
+
           values.forEach((value, index) => {
-            if (values.indexOf(value) !== values.lastIndexOf(value)) {
+            if (taken.has(value)) {
+              duplicates.add(value)
+            } else {
+              taken.add(value)
+            }
+          })
+
+          values.forEach((value, index) => {
+            if (duplicates.has(value)) {
               errors[index] = {
                 ...errors[index],
                 [field.key]: {

--- a/src/steps/ValidationStep/utils/dataMutations.ts
+++ b/src/steps/ValidationStep/utils/dataMutations.ts
@@ -34,7 +34,12 @@ export const addErrorsAndRunHooks = <T extends string>(
           const taken = new Set() // Set of items used at least once
           const duplicates = new Set() // Set of items used multiple times
 
-          values.forEach((value, index) => {
+          values.forEach((value) => {
+            if (validation.allowEmpty && !value) {
+              // If allowEmpty is set, we will not validate falsy fields such as undefined or empty string.
+              return
+            }
+
             if (taken.has(value)) {
               duplicates.add(value)
             } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,10 +85,17 @@ export type Input = {
   type: "input"
 }
 
-export type Validation = BasicValidation | RegexValidation
+export type Validation = RequiredValidation | UniqueValidation | RegexValidation
 
-export type BasicValidation = {
-  rule: "unique" | "required" //... to be determined
+export type RequiredValidation = {
+  rule: "required"
+  errorMessage?: string
+  level?: ErrorLevel
+}
+
+export type UniqueValidation = {
+  rule: "unique"
+  allowEmpty?: boolean
   errorMessage?: string
   level?: ErrorLevel
 }


### PR DESCRIPTION
This should be two separate PRs, but since they are closely related I decided to submit them as one.

**Performance**
The current O(n^2) implementation of checking for unique values is quite slow on larger datasets.
For my test file with 11k rows, this change brings down the time to 5ms from over a second.

**allowEmpty**
For our use case, we need some way to specify that a field is optional, but if it is specified the values have to be unique. This is useful for for example an id field, where we can generate ids if not specified.

IMO the optimal solution would be to set allowEmpty to the default behaviour, and let users combine required and unique to get the current behaviour. But since that would be breaking, I simply opted to add an allowEmpty setting that skips the unique check for empty fields.