### PR TITLE
WIP: Explicitly set border style for the match icon

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -42,6 +42,7 @@ const MatchIconTheme: any = {
       borderColor: "yellow.500",
       color: "background",
       transitionDuration: "ultra-fast",
+      borderStyle: "solid",
     }
   },
   defaultProps: {


### PR DESCRIPTION
Your storybook includes a reset style `border-style: solid`. I'm working on integrating this import flow into a project which does not have such a reset style, and therefore the orange circle icon is not visible.

PS: Thanks for open sourcing this component, it will save us a lot of time as opposed to implementing something similar from scratch! It's working really well out of the box with only a few minor tweaks being needed for our use case.

**Update:**
More style "fixes" coming if you are interested in supporting users not using the default chakra ui reset.