### PR TITLE
Fix - calc for 'will become' title in a single column

### DIFF
--- a/src/steps/MatchColumnsStep/components/ColumnGrid.tsx
+++ b/src/steps/MatchColumnsStep/components/ColumnGrid.tsx
@@ -45,7 +45,7 @@ export const ColumnGrid = <T extends string>({
             </Box>
           ))}
           <FadingWrapper gridColumn={`1/${columns.length + 3}`} gridRow="2/3" />
-          <Box gridColumn={`1/${columns.length + 1}`} mt={7}>
+          <Box gridColumn={`1/${columns.length + 3}`} mt={7}>
             <Text sx={styles.title}>{translations.matchColumnsStep.templateTitle}</Text>
           </Box>
           <FadingWrapper gridColumn={`1/${columns.length + 3}`} gridRow="4/5" />


### PR DESCRIPTION
When a single column CSV is used - the "will become" title is not using the right width (like the "Your table" title)