### PR TITLE
chore UGN-355 - render error toast if error is thrown in async hook

### DIFF
--- a/src/steps/SelectHeaderStep/tests/SelectHeaderStep.test.tsx
+++ b/src/steps/SelectHeaderStep/tests/SelectHeaderStep.test.tsx
@@ -11,6 +11,7 @@ import { StepType } from "../../UploadFlow"
 
 const MUTATED_HEADER = "mutated header"
 const CONTINUE_BUTTON = "Next"
+const ERROR_MESSAGE = "Something happened"
 
 test("Select header row and click next", async () => {
   const data = [
@@ -64,7 +65,7 @@ test("selectHeaderStepHook should be called after header is selected", async () 
       ],
     },
   })
-  const continueButton = await screen.findByText(CONTINUE_BUTTON, undefined, { timeout: 5000 })
+  const continueButton = await screen.findByText(CONTINUE_BUTTON, undefined, { timeout: 10000 })
   fireEvent.click(continueButton)
   await waitFor(() => {
     expect(selectHeaderStepHook).toBeCalledWith(
@@ -102,5 +103,34 @@ test("selectHeaderStepHook should be able to modify raw data", async () => {
 
   await waitFor(() => {
     expect(mutatedHeader).toBeInTheDocument()
+  })
+})
+
+test("Should show error toast if error is thrown in selectHeaderStepHook", async () => {
+  const selectHeaderStepHook = jest.fn(async () => {
+    throw new Error(ERROR_MESSAGE)
+    return undefined as any
+  })
+  render(
+    <ReactSpreadsheetImport
+      {...mockRsiValues}
+      selectHeaderStepHook={selectHeaderStepHook}
+      initialStepState={{
+        type: StepType.selectHeader,
+        data: [
+          ["name", "age"],
+          ["Josh", "2"],
+          ["Charlie", "3"],
+          ["Lena", "50"],
+        ],
+      }}
+    />,
+  )
+  const continueButton = screen.getByText(CONTINUE_BUTTON)
+  fireEvent.click(continueButton)
+  const errorToast = await screen.findByText(ERROR_MESSAGE)
+
+  await waitFor(() => {
+    expect(errorToast).toBeInTheDocument()
   })
 })

--- a/src/steps/UploadStep/tests/UploadStep.test.tsx
+++ b/src/steps/UploadStep/tests/UploadStep.test.tsx
@@ -7,6 +7,7 @@ import { Providers } from "../../../components/Providers"
 import { ModalWrapper } from "../../../components/ModalWrapper"
 
 const MUTATED_RAW_DATA = "Bye"
+const ERROR_MESSAGE = 'Something happened'
 
 test("Upload a file", async () => {
   const file = new File(["Hello, Hello, Hello, Hello"], "test.csv", { type: "text/csv" })
@@ -65,4 +66,21 @@ test("uploadStepHook should be able to mutate raw upload data", async () => {
 
   const el = await screen.findByText(MUTATED_RAW_DATA, undefined, { timeout: 5000 })
   expect(el).toBeInTheDocument()
+})
+
+test("Should show error toast if error is thrown in uploadStepHook", async () => {
+  const file = new File(["Hello, Hello, Hello, Hello"], "test.csv", { type: "text/csv" })
+  const uploadStepHook = jest.fn(async () => {
+    throw new Error(ERROR_MESSAGE)
+    return undefined as any
+  })
+  render(<ReactSpreadsheetImport {...mockRsiValues} uploadStepHook={uploadStepHook} />)
+
+  const uploader = screen.getByTestId("rsi-dropzone")
+  fireEvent.drop(uploader, {
+    target: { files: [file] },
+  })
+
+  const errorToast = await screen.findByText(ERROR_MESSAGE, undefined, { timeout: 5000 })
+  expect(errorToast).toBeInTheDocument()
 })

--- a/src/steps/UploadStep/tests/UploadStep.test.tsx
+++ b/src/steps/UploadStep/tests/UploadStep.test.tsx
@@ -7,7 +7,7 @@ import { Providers } from "../../../components/Providers"
 import { ModalWrapper } from "../../../components/ModalWrapper"
 
 const MUTATED_RAW_DATA = "Bye"
-const ERROR_MESSAGE = 'Something happened'
+const ERROR_MESSAGE = "Something happened"
 
 test("Upload a file", async () => {
   const file = new File(["Hello, Hello, Hello, Hello"], "test.csv", { type: "text/csv" })

--- a/src/translationsRSIProps.ts
+++ b/src/translationsRSIProps.ts
@@ -64,6 +64,9 @@ export const translations = {
       cancelButtonTitle: "Cancel",
       continueButtonTitle: "Continue",
     },
+    toast: {
+      error: "Error",
+    },
   },
 }
 


### PR DESCRIPTION
- catch errors in async hooks: uploadStepHook, selectHeaderStepHook and matchColumnsStepHook
- show an error toast if error is thrown 
<img width="1173" alt="Screenshot 2022-06-01 at 16 59 48" src="https://user-images.githubusercontent.com/45755753/171424147-9603c08e-f9d2-43e1-8fcf-4c9009400868.png">
