### PR TITLE
Default date format for worksheet parsing

### DIFF
--- a/src/ReactSpreadsheetImport.tsx
+++ b/src/ReactSpreadsheetImport.tsx
@@ -17,6 +17,7 @@ export const defaultRSIProps: Partial<RsiProps<any>> = {
   uploadStepHook: async (value) => value,
   selectHeaderStepHook: async (headerValues, data) => ({ headerValues, data }),
   matchColumnsStepHook: async (table) => table,
+  dateFormat: "yyyy-mm-dd", // ISO 8601
 } as const
 
 export const ReactSpreadsheetImport = <T extends string>(props: RsiProps<T>) => {

--- a/src/steps/UploadStep/components/DropZone.tsx
+++ b/src/steps/UploadStep/components/DropZone.tsx
@@ -13,7 +13,7 @@ type DropZoneProps = {
 }
 
 export const DropZone = ({ onContinue, isLoading }: DropZoneProps) => {
-  const { translations, maxFileSize } = useRsi()
+  const { translations, maxFileSize, dateFormat } = useRsi()
   const styles = useStyleConfig("UploadStep") as typeof themeOverrides["components"]["UploadStep"]["baseStyle"]
   const toast = useToast()
   const [loading, setLoading] = useState(false)
@@ -39,7 +39,7 @@ export const DropZone = ({ onContinue, isLoading }: DropZoneProps) => {
     onDrop: async ([file]) => {
       setLoading(true)
       const arrayBuffer = await readFileAsync(file)
-      const workbook = XLSX.read(arrayBuffer)
+      const workbook = XLSX.read(arrayBuffer, { cellDates: true, dateNF: dateFormat })
       setLoading(false)
       onContinue(workbook)
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,8 @@ export type RsiProps<T extends string> = {
   autoMapDistance?: number
   // initial Step state to be rendered on load
   initialStepState?: StepState
+  // Date format to use
+  dateFormat?: string
 }
 
 export type RawData = Array<string | undefined>

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,7 +37,7 @@ export type RsiProps<T extends string> = {
   autoMapHeaders?: boolean
   // Headers matching accuracy: 1 for strict and up for more flexible matching
   autoMapDistance?: number
-  // initial Step state to be rendered on load
+  // Initial Step state to be rendered on load
   initialStepState?: StepState
   // Date format to use
   dateFormat?: string


### PR DESCRIPTION
Fix for this issue : #110 
Date 02/02/1923 and 02/02/2023 were both formatted to 2/2/23

- Added parameter dateFormat with default value YYYY-MM-DD (ISO 8601 format)