### PR TITLE
fix header select display issue on safari

### DIFF
--- a/src/steps/SelectHeaderStep/SelectHeaderStep.tsx
+++ b/src/steps/SelectHeaderStep/SelectHeaderStep.tsx
@@ -32,7 +32,7 @@ export const SelectHeaderStep = ({ data, onContinue }: SelectHeaderProps) => {
     <>
       <ModalBody pb={0}>
         <Heading {...styles.heading}>{translations.selectHeaderStep.title}</Heading>
-        <Box h={0} flexGrow={1}>
+        <Box flexGrow={1}>
           <SelectHeaderTable data={data} selectedRows={selectedRows} setSelectedRows={setSelectedRows} />
         </Box>
       </ModalBody>


### PR DESCRIPTION
Setting height to 0px causes the header selection table not to show on Safari.

fixes #179

Tested on Chrome and Safari.