### PR TITLE
Validation hooks fixes

### DIFF
--- a/src/steps/ValidationStep/ValidationStep.tsx
+++ b/src/steps/ValidationStep/ValidationStep.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useMemo, useState, useEffect } from "react"
 import { Box, Button, Heading, ModalBody, Switch, useStyleConfig } from "@chakra-ui/react"
 import { ContinueButton } from "../../components/ContinueButton"
 import { useRsi } from "../../hooks/useRsi"
@@ -22,20 +22,18 @@ export const ValidationStep = <T extends string>({ initialData, file }: Props<T>
     "ValidationStep",
   ) as (typeof themeOverrides)["components"]["ValidationStep"]["baseStyle"]
 
-  const [data, setData] = useState<(Data<T> & Meta)[]>(
-    useMemo(
-      () => addErrorsAndRunHooks<T>(initialData, fields, rowHook, tableHook),
-      // eslint-disable-next-line react-hooks/exhaustive-deps
-      [],
-    ),
-  )
+  const [data, setData] = useState<(Data<T> & Meta)[]>(initialData as (Data<T> & Meta)[])
+  useEffect(() => {
+    addErrorsAndRunHooks<T>(initialData, fields, rowHook, tableHook).then((data) => setData(data))
+  }, [initialData, fields, rowHook, tableHook])
+
   const [selectedRows, setSelectedRows] = useState<ReadonlySet<number | string>>(new Set())
   const [filterByErrors, setFilterByErrors] = useState(false)
   const [showSubmitAlert, setShowSubmitAlert] = useState(false)
 
   const updateData = useCallback(
-    (rows: typeof data) => {
-      setData(addErrorsAndRunHooks<T>(rows, fields, rowHook, tableHook))
+    async (rows: typeof data, indexes?: number[]) => {
+      setData(await addErrorsAndRunHooks<T>(rows, fields, rowHook, tableHook, indexes))
     },
     [setData, rowHook, tableHook, fields],
   )
@@ -48,7 +46,7 @@ export const ValidationStep = <T extends string>({ initialData, file }: Props<T>
     }
   }
 
-  const updateRow = useCallback(
+  const updateRows = useCallback(
     (rows: typeof data, changedData?: RowsChangeData<(typeof data)[number]>) => {
       const changes = changedData?.indexes.reduce((acc, index) => {
         // when data is filtered val !== actual index in data
@@ -56,8 +54,9 @@ export const ValidationStep = <T extends string>({ initialData, file }: Props<T>
         acc[realIndex] = rows[index]
         return acc
       }, {} as Record<number, (typeof data)[number]>)
+      const realIndexes = changes == null ? undefined : Object.keys(changes).map((index) => Number(index))
       const newData = Object.assign([], data, changes)
-      updateData(newData)
+      updateData(newData, realIndexes)
     },
     [data, updateData],
   )
@@ -137,7 +136,7 @@ export const ValidationStep = <T extends string>({ initialData, file }: Props<T>
           <Table
             rowKeyGetter={rowKeyGetter}
             rows={tableData}
-            onRowsChange={updateRow}
+            onRowsChange={updateRows}
             columns={columns}
             selectedRows={selectedRows}
             onSelectedRowsChange={setSelectedRows}

--- a/src/steps/ValidationStep/tests/ValidationStep.test.tsx
+++ b/src/steps/ValidationStep/tests/ValidationStep.test.tsx
@@ -609,11 +609,9 @@ describe("Validation step tests", () => {
     expect(lastNameCell).toBeInTheDocument()
 
     // activate input
-    await act(async () => {
-      await userEvent.click(nameCell)
+    await userEvent.click(nameCell)
 
-      await userEvent.keyboard(NEW_NAME + " " + NEW_LASTNAME + "{enter}")
-    })
+    await userEvent.keyboard(NEW_NAME + " " + NEW_LASTNAME + "{enter}")
 
     const newNameCell = screen.getByRole("gridcell", {
       name: NEW_NAME,

--- a/src/steps/ValidationStep/tests/ValidationStep.test.tsx
+++ b/src/steps/ValidationStep/tests/ValidationStep.test.tsx
@@ -1,5 +1,5 @@
 import "@testing-library/jest-dom"
-import { render, waitFor, screen } from "@testing-library/react"
+import { render, waitFor, screen, act } from "@testing-library/react"
 import { ValidationStep } from "../ValidationStep"
 import { defaultRSIProps, defaultTheme } from "../../../ReactSpreadsheetImport"
 import { Providers } from "../../../components/Providers"
@@ -579,23 +579,25 @@ describe("Validation step tests", () => {
       },
     ] as const
 
-    render(
-      <Providers
-        theme={defaultTheme}
-        rsiValues={{
-          ...mockValues,
-          fields,
-          rowHook: (value) => ({
-            name: value.name?.toString()?.split(/(\s+)/)[0],
-            lastName: value.name?.toString()?.split(/(\s+)/)[2],
-          }),
-        }}
-      >
-        <ModalWrapper isOpen={true} onClose={() => {}}>
-          <ValidationStep initialData={initialData} file={file} />
-        </ModalWrapper>
-      </Providers>,
-    )
+    await act(async () => {
+      render(
+        <Providers
+          theme={defaultTheme}
+          rsiValues={{
+            ...mockValues,
+            fields,
+            rowHook: (value) => ({
+              name: value.name?.toString()?.split(/(\s+)/)[0],
+              lastName: value.name?.toString()?.split(/(\s+)/)[2],
+            }),
+          }}
+        >
+          <ModalWrapper isOpen={true} onClose={() => {}}>
+            <ValidationStep initialData={initialData} file={file} />
+          </ModalWrapper>
+        </Providers>,
+      )
+    })
 
     const nameCell = screen.getByRole("gridcell", {
       name: NAME,
@@ -607,9 +609,11 @@ describe("Validation step tests", () => {
     expect(lastNameCell).toBeInTheDocument()
 
     // activate input
-    await userEvent.click(nameCell)
+    await act(async () => {
+      await userEvent.click(nameCell)
 
-    await userEvent.keyboard(NEW_NAME + " " + NEW_LASTNAME + "{enter}")
+      await userEvent.keyboard(NEW_NAME + " " + NEW_LASTNAME + "{enter}")
+    })
 
     const newNameCell = screen.getByRole("gridcell", {
       name: NEW_NAME,
@@ -620,6 +624,7 @@ describe("Validation step tests", () => {
     })
     expect(newLastNameCell).toBeInTheDocument()
   })
+
   test("Row hook raises error", async () => {
     const WRONG_NAME = "Johnny"
     const RIGHT_NAME = "Jonathan"
@@ -638,24 +643,26 @@ describe("Validation step tests", () => {
       },
     ] as const
 
-    render(
-      <Providers
-        theme={defaultTheme}
-        rsiValues={{
-          ...mockValues,
-          fields,
-          rowHook: (value, setError) => {
-            if (value.name === WRONG_NAME) {
-              setError(fields[0].key, { message: "Wrong name", level: "error" })
-            }
-            return value
-          },
-        }}
-      >
-        <ModalWrapper isOpen={true} onClose={() => {}}>
-          <ValidationStep initialData={initialData} file={file} />
-        </ModalWrapper>
-      </Providers>,
+    await act(async () =>
+      render(
+        <Providers
+          theme={defaultTheme}
+          rsiValues={{
+            ...mockValues,
+            fields,
+            rowHook: (value, setError) => {
+              if (value.name === WRONG_NAME) {
+                setError(fields[0].key, { message: "Wrong name", level: "error" })
+              }
+              return value
+            },
+          }}
+        >
+          <ModalWrapper isOpen={true} onClose={() => {}}>
+            <ValidationStep initialData={initialData} file={file} />
+          </ModalWrapper>
+        </Providers>,
+      ),
     )
 
     const switchFilter = getFilterSwitch()
@@ -702,23 +709,25 @@ describe("Validation step tests", () => {
       },
     ] as const
 
-    render(
-      <Providers
-        theme={defaultTheme}
-        rsiValues={{
-          ...mockValues,
-          fields,
-          tableHook: (data) =>
-            data.map((value) => ({
-              name: value.name + ADDITION,
-            })),
-        }}
-      >
-        <ModalWrapper isOpen={true} onClose={() => {}}>
-          <ValidationStep initialData={initialData} file={file} />
-        </ModalWrapper>
-      </Providers>,
-    )
+    await act(async () => {
+      render(
+        <Providers
+          theme={defaultTheme}
+          rsiValues={{
+            ...mockValues,
+            fields,
+            tableHook: (data) =>
+              data.map((value) => ({
+                name: value.name + ADDITION,
+              })),
+          }}
+        >
+          <ModalWrapper isOpen={true} onClose={() => {}}>
+            <ValidationStep initialData={initialData} file={file} />
+          </ModalWrapper>
+        </Providers>,
+      )
+    })
 
     const nameCell = screen.getByRole("gridcell", {
       name: NAME + ADDITION,

--- a/src/steps/ValidationStep/utils/dataMutations.ts
+++ b/src/steps/ValidationStep/utils/dataMutations.ts
@@ -24,7 +24,9 @@ export const addErrorsAndRunHooks = async <T extends string>(
 
   if (rowHook) {
     if (changedRowIndexes != null) {
-      changedRowIndexes.forEach((index) => rowHook(data[index], (...props) => addHookError(index, ...props), data))
+      for (const index of changedRowIndexes) {
+        data[index] = await rowHook(data[index], (...props) => addHookError(index, ...props), data)
+      }
     } else {
       data = await Promise.all(
         data.map(async (value, index) => rowHook(value, (...props) => addHookError(index, ...props), data)),

--- a/src/steps/ValidationStep/utils/dataMutations.ts
+++ b/src/steps/ValidationStep/utils/dataMutations.ts
@@ -2,12 +2,13 @@ import type { Data, Fields, Info, RowHook, TableHook } from "../../../types"
 import type { Meta, Errors } from "../types"
 import { v4 } from "uuid"
 
-export const addErrorsAndRunHooks = <T extends string>(
+export const addErrorsAndRunHooks = async <T extends string>(
   data: (Data<T> & Partial<Meta>)[],
   fields: Fields<T>,
   rowHook?: RowHook<T>,
   tableHook?: TableHook<T>,
-): (Data<T> & Meta)[] => {
+  changedRowIndexes?: number[],
+): Promise<(Data<T> & Meta)[]> => {
   const errors: Errors = {}
 
   const addHookError = (rowIndex: number, fieldKey: T, error: Info) => {
@@ -18,11 +19,17 @@ export const addErrorsAndRunHooks = <T extends string>(
   }
 
   if (tableHook) {
-    data = tableHook(data, addHookError)
+    data = await tableHook(data, addHookError)
   }
 
   if (rowHook) {
-    data = data.map((value, index) => rowHook(value, (...props) => addHookError(index, ...props), data))
+    if (changedRowIndexes != null) {
+      changedRowIndexes.forEach((index) => rowHook(data[index], (...props) => addHookError(index, ...props), data))
+    } else {
+      data = await Promise.all(
+        data.map(async (value, index) => rowHook(value, (...props) => addHookError(index, ...props), data)),
+      )
+    }
   }
 
   fields.forEach((field) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,11 +121,11 @@ export type RowHook<T extends string> = (
   row: Data<T>,
   addError: (fieldKey: T, error: Info) => void,
   table: Data<T>[],
-) => Data<T>
+) => Data<T> | Promise<Data<T>>
 export type TableHook<T extends string> = (
   table: Data<T>[],
   addError: (rowIndex: number, fieldKey: T, error: Info) => void,
-) => Data<T>[]
+) => Data<T>[] | Promise<Data<T>[]>
 
 export type ErrorLevel = "info" | "warning" | "error"
 


### PR DESCRIPTION
This pull request fixes two issues:
- #137 
- #139 

It restricts rowHook to run only on changed rows when called by the rows changed event (it should still run on all rows initially). It also turns rowHook **and tableHook** into (optionally) async functions. The relevant tests have also been updated to accept asynchronous functionality.