### PR TITLE
Fix close button disappearing on scroll

### DIFF
--- a/src/components/ModalCloseButton.tsx
+++ b/src/components/ModalCloseButton.tsx
@@ -29,7 +29,7 @@ export const ModalCloseButton = ({ onClose }: ModalCloseButtonProps) => {
         aria-label="Close modal"
         icon={<CgClose />}
         color="white"
-        position="absolute"
+        position="fixed"
         transform="translate(50%, -50%)"
         onClick={() => setShowModal(true)}
         zIndex="toast"


### PR DESCRIPTION
Close button should be positioned fixed from screen, not absolute from parent. This behaviour can be overridden in a standard way with theme `closeModalButton` style.