### PR TITLE
Automatch select values

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ Common date-time formats can be viewed [here](https://docs.sheetjs.com/docs/csf/
   maxFileSize?: number
   // Automatically map imported headers to specified fields if possible. Default: true
   autoMapHeaders?: boolean
+  // When field type is "select", automatically match values if possible. Default: true
+  autoMapSelectValues?: boolean
   // Headers matching accuracy: 1 for strict and up for more flexible matching. Default: 2
   autoMapDistance?: number
 ```

--- a/src/ReactSpreadsheetImport.tsx
+++ b/src/ReactSpreadsheetImport.tsx
@@ -11,6 +11,7 @@ export const defaultTheme = themeOverrides
 
 export const defaultRSIProps: Partial<RsiProps<any>> = {
   autoMapHeaders: true,
+  autoMapSelectValues: false,
   allowInvalidSubmit: true,
   autoMapDistance: 2,
   translations: translations,

--- a/src/steps/MatchColumnsStep/MatchColumnsStep.tsx
+++ b/src/steps/MatchColumnsStep/MatchColumnsStep.tsx
@@ -99,6 +99,7 @@ export const MatchColumnsStep = <T extends string>({ data, headerValues, onConti
       )
     },
     [
+      autoMapSelectValues,
       columns,
       data,
       fields,
@@ -151,12 +152,15 @@ export const MatchColumnsStep = <T extends string>({ data, headerValues, onConti
     setIsLoading(false)
   }, [onContinue, columns, data, fields])
 
-  useEffect(() => {
-    if (autoMapHeaders) {
-      setColumns(getMatchedColumns(columns, fields, data, autoMapDistance, autoMapSelectValues))
-    }
+  useEffect(
+    () => {
+      if (autoMapHeaders) {
+        setColumns(getMatchedColumns(columns, fields, data, autoMapDistance, autoMapSelectValues))
+      }
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+    [],
+  )
 
   return (
     <>

--- a/src/steps/MatchColumnsStep/MatchColumnsStep.tsx
+++ b/src/steps/MatchColumnsStep/MatchColumnsStep.tsx
@@ -65,7 +65,7 @@ export type Columns<T extends string> = Column<T>[]
 export const MatchColumnsStep = <T extends string>({ data, headerValues, onContinue }: MatchColumnsProps<T>) => {
   const toast = useToast()
   const dataExample = data.slice(0, 2)
-  const { fields, autoMapHeaders, autoMapDistance, translations } = useRsi<T>()
+  const { fields, autoMapHeaders, autoMapSelectValues, autoMapDistance, translations } = useRsi<T>()
   const [isLoading, setIsLoading] = useState(false)
   const [columns, setColumns] = useState<Columns<T>>(
     // Do not remove spread, it indexes empty array elements, otherwise map() skips over them
@@ -81,7 +81,7 @@ export const MatchColumnsStep = <T extends string>({ data, headerValues, onConti
         columns.map<Column<T>>((column, index) => {
           columnIndex === index ? setColumn(column, field, data) : column
           if (columnIndex === index) {
-            return setColumn(column, field, data)
+            return setColumn(column, field, data, autoMapSelectValues)
           } else if (index === existingFieldIndex) {
             toast({
               status: "warning",
@@ -153,7 +153,7 @@ export const MatchColumnsStep = <T extends string>({ data, headerValues, onConti
 
   useEffect(() => {
     if (autoMapHeaders) {
-      setColumns(getMatchedColumns(columns, fields, data, autoMapDistance))
+      setColumns(getMatchedColumns(columns, fields, data, autoMapDistance, autoMapSelectValues))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])

--- a/src/steps/MatchColumnsStep/components/TemplateColumn.tsx
+++ b/src/steps/MatchColumnsStep/components/TemplateColumn.tsx
@@ -22,7 +22,7 @@ import type { Styles } from "./ColumnGrid"
 const getAccordionTitle = <T extends string>(fields: Fields<T>, column: Column<T>, translations: Translations) => {
   const fieldLabel = fields.find((field) => "value" in column && field.key === column.value)!.label
   return `${translations.matchColumnsStep.matchDropdownTitle} ${fieldLabel} (${
-    "matchedOptions" in column && column.matchedOptions.length
+    "matchedOptions" in column && column.matchedOptions.filter((option) => !option.value).length
   } ${translations.matchColumnsStep.unmatched})`
 }
 

--- a/src/steps/MatchColumnsStep/tests/MatchColumnsStep.test.tsx
+++ b/src/steps/MatchColumnsStep/tests/MatchColumnsStep.test.tsx
@@ -187,23 +187,20 @@ describe("Match Columns automatic matching", () => {
     const OPTION_RESULT_TWO = "Dane"
     const OPTION_RESULT_TWO_VALUE = "2"
     const OPTION_RESULT_THREE = "Kane"
-    const OPTION_RESULT_THREE_VALUE = "3"
     const data = [
+      // match by option label
       [OPTION_RESULT_ONE, "123", "j@j.com"],
-      [OPTION_RESULT_TWO, "333", "dane@bane.com"],
+      // match by option value
+      [OPTION_RESULT_TWO_VALUE, "333", "dane@bane.com"],
+      // do not match
       [OPTION_RESULT_THREE, "534", "kane@linch.com"],
     ]
     const options = [
       { label: OPTION_RESULT_ONE, value: OPTION_RESULT_ONE_VALUE },
       { label: OPTION_RESULT_TWO, value: OPTION_RESULT_TWO_VALUE },
-      { label: OPTION_RESULT_THREE, value: OPTION_RESULT_THREE_VALUE },
     ]
     // finds only names with automatic matching
-    const result = [
-      { name: OPTION_RESULT_ONE_VALUE },
-      { name: OPTION_RESULT_TWO_VALUE },
-      { name: OPTION_RESULT_THREE_VALUE },
-    ]
+    const result = [{ name: OPTION_RESULT_ONE_VALUE }, { name: OPTION_RESULT_TWO_VALUE }, { name: undefined }]
 
     const alternativeFields = [
       {
@@ -230,7 +227,7 @@ describe("Match Columns automatic matching", () => {
       </Providers>,
     )
 
-    expect(screen.getByText(/0 Unmatched/)).toBeInTheDocument()
+    expect(screen.getByText(/1 Unmatched/)).toBeInTheDocument()
 
     const nextButton = screen.getByRole("button", {
       name: "Next",
@@ -251,16 +248,17 @@ describe("Match Columns automatic matching", () => {
     const OPTION_RESULT_TWO = "Dane"
     const OPTION_RESULT_TWO_VALUE = "2"
     const OPTION_RESULT_THREE = "Kane"
-    const OPTION_RESULT_THREE_VALUE = "3"
     const data = [
+      // match by option label
       [OPTION_RESULT_ONE, "123", "j@j.com"],
-      [OPTION_RESULT_TWO, "333", "dane@bane.com"],
+      // match by option value
+      [OPTION_RESULT_TWO_VALUE, "333", "dane@bane.com"],
+      // do not match
       [OPTION_RESULT_THREE, "534", "kane@linch.com"],
     ]
     const options = [
       { label: OPTION_RESULT_ONE, value: OPTION_RESULT_ONE_VALUE },
       { label: OPTION_RESULT_TWO, value: OPTION_RESULT_TWO_VALUE },
-      { label: OPTION_RESULT_THREE, value: OPTION_RESULT_THREE_VALUE },
     ]
     const result = [{ name: undefined }, { name: undefined }, { name: undefined }]
 
@@ -310,23 +308,20 @@ describe("Match Columns automatic matching", () => {
     const OPTION_RESULT_TWO = "Dane"
     const OPTION_RESULT_TWO_VALUE = "2"
     const OPTION_RESULT_THREE = "Kane"
-    const OPTION_RESULT_THREE_VALUE = "3"
     const data = [
+      // match by option label
       [OPTION_RESULT_ONE, "123", "j@j.com"],
-      [OPTION_RESULT_TWO, "333", "dane@bane.com"],
+      // match by option value
+      [OPTION_RESULT_TWO_VALUE, "333", "dane@bane.com"],
+      // do not match
       [OPTION_RESULT_THREE, "534", "kane@linch.com"],
     ]
     const options = [
       { label: OPTION_RESULT_ONE, value: OPTION_RESULT_ONE_VALUE },
       { label: OPTION_RESULT_TWO, value: OPTION_RESULT_TWO_VALUE },
-      { label: OPTION_RESULT_THREE, value: OPTION_RESULT_THREE_VALUE },
     ]
     // finds only names with automatic matching
-    const result = [
-      { name: OPTION_RESULT_ONE_VALUE },
-      { name: OPTION_RESULT_TWO_VALUE },
-      { name: OPTION_RESULT_THREE_VALUE },
-    ]
+    const result = [{ name: OPTION_RESULT_ONE_VALUE }, { name: OPTION_RESULT_TWO_VALUE }, { name: undefined }]
 
     const alternativeFields = [
       {
@@ -357,7 +352,7 @@ describe("Match Columns automatic matching", () => {
       container: document.getElementById(SELECT_DROPDOWN_ID)!,
     })
 
-    expect(screen.getByText(/0 Unmatched/)).toBeInTheDocument()
+    expect(screen.getByText(/1 Unmatched/)).toBeInTheDocument()
 
     const nextButton = screen.getByRole("button", {
       name: "Next",

--- a/src/steps/MatchColumnsStep/tests/MatchColumnsStep.test.tsx
+++ b/src/steps/MatchColumnsStep/tests/MatchColumnsStep.test.tsx
@@ -180,6 +180,197 @@ describe("Match Columns automatic matching", () => {
     expect(onContinue.mock.calls[0][0]).toEqual(result)
   })
 
+  test("AutoMatches select values on mount", async () => {
+    const header = ["first name", "count", "Email"]
+    const OPTION_RESULT_ONE = "John"
+    const OPTION_RESULT_ONE_VALUE = "1"
+    const OPTION_RESULT_TWO = "Dane"
+    const OPTION_RESULT_TWO_VALUE = "2"
+    const OPTION_RESULT_THREE = "Kane"
+    const OPTION_RESULT_THREE_VALUE = "3"
+    const data = [
+      [OPTION_RESULT_ONE, "123", "j@j.com"],
+      [OPTION_RESULT_TWO, "333", "dane@bane.com"],
+      [OPTION_RESULT_THREE, "534", "kane@linch.com"],
+    ]
+    const options = [
+      { label: OPTION_RESULT_ONE, value: OPTION_RESULT_ONE_VALUE },
+      { label: OPTION_RESULT_TWO, value: OPTION_RESULT_TWO_VALUE },
+      { label: OPTION_RESULT_THREE, value: OPTION_RESULT_THREE_VALUE },
+    ]
+    // finds only names with automatic matching
+    const result = [
+      { name: OPTION_RESULT_ONE_VALUE },
+      { name: OPTION_RESULT_TWO_VALUE },
+      { name: OPTION_RESULT_THREE_VALUE },
+    ]
+
+    const alternativeFields = [
+      {
+        label: "Name",
+        key: "name",
+        alternateMatches: ["first name"],
+        fieldType: {
+          type: "select",
+          options,
+        },
+        example: "Stephanie",
+      },
+    ] as const
+
+    const onContinue = jest.fn()
+    render(
+      <Providers
+        theme={defaultTheme}
+        rsiValues={{ ...mockRsiValues, fields: alternativeFields, autoMapSelectValues: true }}
+      >
+        <ModalWrapper isOpen={true} onClose={() => {}}>
+          <MatchColumnsStep headerValues={header} data={data} onContinue={onContinue} />
+        </ModalWrapper>
+      </Providers>,
+    )
+
+    expect(screen.getByText(/0 Unmatched/)).toBeInTheDocument()
+
+    const nextButton = screen.getByRole("button", {
+      name: "Next",
+    })
+
+    await userEvent.click(nextButton)
+
+    await waitFor(() => {
+      expect(onContinue).toBeCalled()
+    })
+    expect(onContinue.mock.calls[0][0]).toEqual(result)
+  })
+
+  test("Does not auto match select values when autoMapSelectValues:false", async () => {
+    const header = ["first name", "count", "Email"]
+    const OPTION_RESULT_ONE = "John"
+    const OPTION_RESULT_ONE_VALUE = "1"
+    const OPTION_RESULT_TWO = "Dane"
+    const OPTION_RESULT_TWO_VALUE = "2"
+    const OPTION_RESULT_THREE = "Kane"
+    const OPTION_RESULT_THREE_VALUE = "3"
+    const data = [
+      [OPTION_RESULT_ONE, "123", "j@j.com"],
+      [OPTION_RESULT_TWO, "333", "dane@bane.com"],
+      [OPTION_RESULT_THREE, "534", "kane@linch.com"],
+    ]
+    const options = [
+      { label: OPTION_RESULT_ONE, value: OPTION_RESULT_ONE_VALUE },
+      { label: OPTION_RESULT_TWO, value: OPTION_RESULT_TWO_VALUE },
+      { label: OPTION_RESULT_THREE, value: OPTION_RESULT_THREE_VALUE },
+    ]
+    const result = [{ name: undefined }, { name: undefined }, { name: undefined }]
+
+    const alternativeFields = [
+      {
+        label: "Name",
+        key: "name",
+        alternateMatches: ["first name"],
+        fieldType: {
+          type: "select",
+          options,
+        },
+        example: "Stephanie",
+      },
+    ] as const
+
+    const onContinue = jest.fn()
+    render(
+      <Providers
+        theme={defaultTheme}
+        rsiValues={{ ...mockRsiValues, fields: alternativeFields, autoMapSelectValues: false }}
+      >
+        <ModalWrapper isOpen={true} onClose={() => {}}>
+          <MatchColumnsStep headerValues={header} data={data} onContinue={onContinue} />
+        </ModalWrapper>
+      </Providers>,
+    )
+
+    expect(screen.getByText(/3 Unmatched/)).toBeInTheDocument()
+
+    const nextButton = screen.getByRole("button", {
+      name: "Next",
+    })
+
+    await userEvent.click(nextButton)
+
+    await waitFor(() => {
+      expect(onContinue).toBeCalled()
+    })
+    expect(onContinue.mock.calls[0][0]).toEqual(result)
+  })
+
+  test("AutoMatches select values on select", async () => {
+    const header = ["first name", "count", "Email"]
+    const OPTION_RESULT_ONE = "John"
+    const OPTION_RESULT_ONE_VALUE = "1"
+    const OPTION_RESULT_TWO = "Dane"
+    const OPTION_RESULT_TWO_VALUE = "2"
+    const OPTION_RESULT_THREE = "Kane"
+    const OPTION_RESULT_THREE_VALUE = "3"
+    const data = [
+      [OPTION_RESULT_ONE, "123", "j@j.com"],
+      [OPTION_RESULT_TWO, "333", "dane@bane.com"],
+      [OPTION_RESULT_THREE, "534", "kane@linch.com"],
+    ]
+    const options = [
+      { label: OPTION_RESULT_ONE, value: OPTION_RESULT_ONE_VALUE },
+      { label: OPTION_RESULT_TWO, value: OPTION_RESULT_TWO_VALUE },
+      { label: OPTION_RESULT_THREE, value: OPTION_RESULT_THREE_VALUE },
+    ]
+    // finds only names with automatic matching
+    const result = [
+      { name: OPTION_RESULT_ONE_VALUE },
+      { name: OPTION_RESULT_TWO_VALUE },
+      { name: OPTION_RESULT_THREE_VALUE },
+    ]
+
+    const alternativeFields = [
+      {
+        label: "Name",
+        key: "name",
+        fieldType: {
+          type: "select",
+          options,
+        },
+        example: "Stephanie",
+      },
+    ] as const
+
+    const onContinue = jest.fn()
+    render(
+      <Providers
+        theme={defaultTheme}
+        rsiValues={{ ...mockRsiValues, fields: alternativeFields, autoMapSelectValues: true }}
+      >
+        <ModalWrapper isOpen={true} onClose={() => {}}>
+          <MatchColumnsStep headerValues={header} data={data} onContinue={onContinue} />
+          <div id={SELECT_DROPDOWN_ID} />
+        </ModalWrapper>
+      </Providers>,
+    )
+
+    await selectEvent.select(screen.getByLabelText(header[0]), alternativeFields[0].label, {
+      container: document.getElementById(SELECT_DROPDOWN_ID)!,
+    })
+
+    expect(screen.getByText(/0 Unmatched/)).toBeInTheDocument()
+
+    const nextButton = screen.getByRole("button", {
+      name: "Next",
+    })
+
+    await userEvent.click(nextButton)
+
+    await waitFor(() => {
+      expect(onContinue).toBeCalled()
+    })
+    expect(onContinue.mock.calls[0][0]).toEqual(result)
+  })
+
   test("Boolean-like values are returned as Booleans", async () => {
     const header = ["namezz", "is_cool", "Email"]
     const data = [

--- a/src/steps/MatchColumnsStep/utils/getMatchedColumns.ts
+++ b/src/steps/MatchColumnsStep/utils/getMatchedColumns.ts
@@ -10,6 +10,7 @@ export const getMatchedColumns = <T extends string>(
   fields: Fields<T>,
   data: MatchColumnsProps<T>["data"],
   autoMapDistance: number,
+  autoMapSelectValues?: boolean,
 ) =>
   columns.reduce<Column<T>[]>((arr, column) => {
     const autoMatch = findMatch(column.header, fields, autoMapDistance)
@@ -21,7 +22,7 @@ export const getMatchedColumns = <T extends string>(
         return lavenstein(duplicate.value, duplicate.header) < lavenstein(autoMatch, column.header)
           ? [
               ...arr.slice(0, duplicateIndex),
-              setColumn(arr[duplicateIndex], field, data),
+              setColumn(arr[duplicateIndex], field, data, autoMapSelectValues),
               ...arr.slice(duplicateIndex + 1),
               setColumn(column),
             ]
@@ -29,10 +30,10 @@ export const getMatchedColumns = <T extends string>(
               ...arr.slice(0, duplicateIndex),
               setColumn(arr[duplicateIndex]),
               ...arr.slice(duplicateIndex + 1),
-              setColumn(column, field, data),
+              setColumn(column, field, data, autoMapSelectValues),
             ]
       } else {
-        return [...arr, setColumn(column, field, data)]
+        return [...arr, setColumn(column, field, data, autoMapSelectValues)]
       }
     } else {
       return [...arr, column]

--- a/src/steps/MatchColumnsStep/utils/setColumn.ts
+++ b/src/steps/MatchColumnsStep/utils/setColumn.ts
@@ -1,26 +1,30 @@
 import type { Field } from "../../../types"
-import { Column, ColumnType, MatchColumnsProps } from "../MatchColumnsStep"
+import { Column, ColumnType, MatchColumnsProps, MatchedOptions } from "../MatchColumnsStep"
 import { uniqueEntries } from "./uniqueEntries"
 
 export const setColumn = <T extends string>(
   oldColumn: Column<T>,
   field?: Field<T>,
   data?: MatchColumnsProps<T>["data"],
+  autoMapSelectValues?: boolean,
 ): Column<T> => {
   switch (field?.fieldType.type) {
     case "select":
-      const uniqueData = uniqueEntries(data || [], oldColumn.index)
-      const matchedOptions = uniqueData?.map(option => {
-        const value = field.fieldType.options.find(o => o.value == option.value || o.label == option.entry)?.value
-        return value ? {...option, value} as MatchedOptions<T>  : option as MatchedOptions<T>
-      })
-      const allMatched = matchedOptions.filter(o => o.value).length == uniqueData?.length
+      const options = field.fieldType.options
+      const uniqueData = uniqueEntries(data || [], oldColumn.index) as MatchedOptions<T>[]
+      const matchedOptions = autoMapSelectValues
+        ? uniqueData.map((option) => {
+            const value = options.find((o) => o.value == option.value || o.label == option.entry)?.value
+            return value ? ({ ...option, value } as MatchedOptions<T>) : (option as MatchedOptions<T>)
+          })
+        : uniqueData
+      const allMatched = matchedOptions.filter((o) => o.value).length == uniqueData?.length
 
       return {
         ...oldColumn,
         type: allMatched ? ColumnType.matchedSelectOptions : ColumnType.matchedSelect,
         value: field.key,
-        matchedOptions
+        matchedOptions,
       }
     case "checkbox":
       return { index: oldColumn.index, type: ColumnType.matchedCheckbox, value: field.key, header: oldColumn.header }

--- a/src/steps/MatchColumnsStep/utils/setColumn.ts
+++ b/src/steps/MatchColumnsStep/utils/setColumn.ts
@@ -10,14 +10,14 @@ export const setColumn = <T extends string>(
 ): Column<T> => {
   switch (field?.fieldType.type) {
     case "select":
-      const options = field.fieldType.options
+      const fieldOptions = field.fieldType.options
       const uniqueData = uniqueEntries(data || [], oldColumn.index) as MatchedOptions<T>[]
       const matchedOptions = autoMapSelectValues
-        ? uniqueData.map((option) => {
-            const value = options.find(
-              (fieldOption) => fieldOption.value === option.entry || fieldOption.label === option.entry,
+        ? uniqueData.map((record) => {
+            const value = fieldOptions.find(
+              (fieldOption) => fieldOption.value === record.entry || fieldOption.label === record.entry,
             )?.value
-            return value ? ({ ...option, value } as MatchedOptions<T>) : (option as MatchedOptions<T>)
+            return value ? ({ ...record, value } as MatchedOptions<T>) : (record as MatchedOptions<T>)
           })
         : uniqueData
       const allMatched = matchedOptions.filter((o) => o.value).length == uniqueData?.length

--- a/src/steps/MatchColumnsStep/utils/setColumn.ts
+++ b/src/steps/MatchColumnsStep/utils/setColumn.ts
@@ -14,7 +14,9 @@ export const setColumn = <T extends string>(
       const uniqueData = uniqueEntries(data || [], oldColumn.index) as MatchedOptions<T>[]
       const matchedOptions = autoMapSelectValues
         ? uniqueData.map((option) => {
-            const value = options.find((o) => o.value == option.value || o.label == option.entry)?.value
+            const value = options.find(
+              (fieldOption) => fieldOption.value === option.entry || fieldOption.label === option.entry,
+            )?.value
             return value ? ({ ...option, value } as MatchedOptions<T>) : (option as MatchedOptions<T>)
           })
         : uniqueData

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,8 @@ export type RsiProps<T extends string> = {
   maxFileSize?: number
   // Automatically map imported headers to specified fields if possible. Default: true
   autoMapHeaders?: boolean
+  // When field type is "select", automatically match values if possible. Default: false
+  autoMapSelectValues?: boolean
   // Headers matching accuracy: 1 for strict and up for more flexible matching
   autoMapDistance?: number
   // Initial Step state to be rendered on load


### PR DESCRIPTION
Automatically match select values when value exactly matches the option label. Does not use Levenshtein distance like column calculations due to performance issues. We could return to this when we investigate performance (maybe look for a rust wasm Levenshtein implementation).