### PR TITLE
feat(custom-fields-ugn-master)

### DIFF
--- a/src/steps/MatchColumnsStep/components/MatchIcon.tsx
+++ b/src/steps/MatchColumnsStep/components/MatchIcon.tsx
@@ -1,7 +1,7 @@
 import { chakra, useStyleConfig, Flex } from "@chakra-ui/react"
 import { dataAttr } from "@chakra-ui/utils"
 import { motion } from "framer-motion"
-import { CgAdd, CgCheck } from "react-icons/cg"
+import { CgCheck } from "react-icons/cg"
 
 const MotionFlex = motion(Flex)
 
@@ -15,12 +15,10 @@ const animationConfig = {
 }
 type MatchIconProps = {
   isChecked: boolean
-  isCustom?: boolean
 }
 
 export const MatchIcon = (props: MatchIconProps) => {
   const style = useStyleConfig("MatchIcon", props)
-  const Icon = props.isCustom ? CgAdd : CgCheck
 
   return (
     <chakra.div
@@ -36,7 +34,7 @@ export const MatchIcon = (props: MatchIconProps) => {
     >
       {props.isChecked && (
         <MotionFlex {...animationConfig}>
-          <Icon size="1.5rem" />
+          <CgCheck size="1.5rem" />
         </MotionFlex>
       )}
     </chakra.div>

--- a/src/steps/MatchColumnsStep/components/MatchIcon.tsx
+++ b/src/steps/MatchColumnsStep/components/MatchIcon.tsx
@@ -1,7 +1,7 @@
 import { chakra, useStyleConfig, Flex } from "@chakra-ui/react"
 import { dataAttr } from "@chakra-ui/utils"
 import { motion } from "framer-motion"
-import { CgCheck } from "react-icons/cg"
+import { CgAdd, CgCheck } from "react-icons/cg"
 
 const MotionFlex = motion(Flex)
 
@@ -15,10 +15,12 @@ const animationConfig = {
 }
 type MatchIconProps = {
   isChecked: boolean
+  isCustom?: boolean
 }
 
 export const MatchIcon = (props: MatchIconProps) => {
   const style = useStyleConfig("MatchIcon", props)
+  const Icon = props.isCustom ? CgAdd : CgCheck
 
   return (
     <chakra.div
@@ -34,7 +36,7 @@ export const MatchIcon = (props: MatchIconProps) => {
     >
       {props.isChecked && (
         <MotionFlex {...animationConfig}>
-          <CgCheck size="1.5rem" />
+          <Icon size="1.5rem" />
         </MotionFlex>
       )}
     </chakra.div>

--- a/src/steps/MatchColumnsStep/components/TemplateColumn.tsx
+++ b/src/steps/MatchColumnsStep/components/TemplateColumn.tsx
@@ -44,7 +44,6 @@ export const TemplateColumn = <T extends string>({
   const styles = useStyleConfig("MatchColumnsStep") as Styles
   const customFields = selectColumnCustomFields(column, headerCustomFieldsMap)
   const fields = [...originalFields, ...customFields] as Fields<T>
-  const isCustom = "value" in column && customFields.some((e) => e.key === column.value)
   const isIgnored = column.type === ColumnType.ignored
   const isChecked =
     column.type === ColumnType.matched ||
@@ -73,7 +72,7 @@ export const TemplateColumn = <T extends string>({
                 name={column.header}
               />
             </Box>
-            <MatchIcon isChecked={isChecked} isCustom={isCustom} />
+            <MatchIcon isChecked={isChecked} />
           </Flex>
           {isSelect && (
             <Flex width="100%">

--- a/src/steps/MatchColumnsStep/components/TemplateColumn.tsx
+++ b/src/steps/MatchColumnsStep/components/TemplateColumn.tsx
@@ -11,13 +11,14 @@ import {
 } from "@chakra-ui/react"
 import { useRsi } from "../../../hooks/useRsi"
 import type { Column } from "../MatchColumnsStep"
-import { ColumnType } from "../MatchColumnsStep"
+import { ColumnType, HeaderCustomFieldsMap } from "../MatchColumnsStep"
 import { MatchIcon } from "./MatchIcon"
 import type { Fields } from "../../../types"
 import type { Translations } from "../../../translationsRSIProps"
 import { MatchColumnSelect } from "../../../components/Selects/MatchColumnSelect"
 import { SubMatchingSelect } from "./SubMatchingSelect"
 import type { Styles } from "./ColumnGrid"
+import { selectColumnCustomFields } from "../utils/customFields"
 
 const getAccordionTitle = <T extends string>(fields: Fields<T>, column: Column<T>, translations: Translations) => {
   const fieldLabel = fields.find((field) => "value" in column && field.key === column.value)!.label
@@ -30,18 +31,30 @@ type TemplateColumnProps<T extends string> = {
   onChange: (val: T, index: number) => void
   onSubChange: (val: T, index: number, option: string) => void
   column: Column<T>
+  headerCustomFieldsMap: HeaderCustomFieldsMap
 }
 
-export const TemplateColumn = <T extends string>({ column, onChange, onSubChange }: TemplateColumnProps<T>) => {
-  const { translations, fields } = useRsi<T>()
+export const TemplateColumn = <T extends string>({
+  column,
+  onChange,
+  onSubChange,
+  headerCustomFieldsMap,
+}: TemplateColumnProps<T>) => {
+  const { translations, fields: originalFields } = useRsi<T>()
   const styles = useStyleConfig("MatchColumnsStep") as Styles
+  const customFields = selectColumnCustomFields(column, headerCustomFieldsMap)
+  const fields = [...originalFields, ...customFields] as Fields<T>
+  const isCustom = "value" in column && customFields.some((e) => e.key === column.value)
   const isIgnored = column.type === ColumnType.ignored
   const isChecked =
     column.type === ColumnType.matched ||
     column.type === ColumnType.matchedCheckbox ||
     column.type === ColumnType.matchedSelectOptions
   const isSelect = "matchedOptions" in column
-  const selectOptions = fields.map(({ label, key }) => ({ value: key, label }))
+  const selectOptions = fields.map(({ key, label, dropDownLabel }) => ({
+    value: key,
+    label: dropDownLabel ?? label,
+  }))
   const selectValue = selectOptions.find(({ value }) => "value" in column && column.value === value)
 
   return (
@@ -60,7 +73,7 @@ export const TemplateColumn = <T extends string>({ column, onChange, onSubChange
                 name={column.header}
               />
             </Box>
-            <MatchIcon isChecked={isChecked} />
+            <MatchIcon isChecked={isChecked} isCustom={isCustom} />
           </Flex>
           {isSelect && (
             <Flex width="100%">

--- a/src/steps/MatchColumnsStep/utils/customFields.ts
+++ b/src/steps/MatchColumnsStep/utils/customFields.ts
@@ -1,0 +1,30 @@
+import { Column, Columns, HeaderCustomFieldsMap } from "../MatchColumnsStep"
+import { CustomFieldsHook, Field, Fields } from "../../../types"
+
+export const createHeaderCustomFieldsMap = (columns: Column<string>[], customFieldsHook?: CustomFieldsHook) => {
+  const result: HeaderCustomFieldsMap = {}
+  if (!customFieldsHook) return result
+  for (const column of columns) {
+    result[column.header as string] = customFieldsHook(column)
+  }
+  return result
+}
+
+export const mergeCustomFields = <T extends string>(
+  columns: Columns<T>,
+  fields: Fields<T>,
+  headerCustomFieldsMap: HeaderCustomFieldsMap,
+) => {
+  const mergedFields = [...fields] as Field<string>[]
+  for (const column of columns) {
+    if (!("value" in column)) continue
+    const customField = headerCustomFieldsMap[column.header as string]?.find((field) => field.key === column.value)
+    if (!customField) continue
+    mergedFields.splice(column.index, 0, customField)
+  }
+  return mergedFields as unknown as Fields<T>
+}
+
+export const selectColumnCustomFields = (column: Column<string>, headerCustomFieldsMap: HeaderCustomFieldsMap) => {
+  return headerCustomFieldsMap[column.header as string] ?? []
+}

--- a/src/steps/MatchColumnsStep/utils/customFields.ts
+++ b/src/steps/MatchColumnsStep/utils/customFields.ts
@@ -15,14 +15,15 @@ export const mergeCustomFields = <T extends string>(
   fields: Fields<T>,
   headerCustomFieldsMap: HeaderCustomFieldsMap,
 ) => {
-  const mergedFields = [...fields] as Field<string>[]
+  const customFields: Field<string>[] = []
   for (const column of columns) {
     if (!("value" in column)) continue
-    const customField = headerCustomFieldsMap[column.header as string]?.find((field) => field.key === column.value)
+    const columnCustomField = selectColumnCustomFields(column, headerCustomFieldsMap)
+    const customField = columnCustomField.find((field) => field.key === column.value)
     if (!customField) continue
-    mergedFields.splice(column.index, 0, customField)
+    customFields.push(customField)
   }
-  return mergedFields as unknown as Fields<T>
+  return [...fields, ...customFields] as Fields<T>
 }
 
 export const selectColumnCustomFields = (column: Column<string>, headerCustomFieldsMap: HeaderCustomFieldsMap) => {

--- a/src/steps/UploadFlow.tsx
+++ b/src/steps/UploadFlow.tsx
@@ -10,7 +10,7 @@ import { addErrorsAndRunHooks } from "./ValidationStep/utils/dataMutations"
 import { MatchColumnsStep } from "./MatchColumnsStep/MatchColumnsStep"
 import { exceedsMaxRecords } from "../utils/exceedsMaxRecords"
 import { useRsi } from "../hooks/useRsi"
-import type { RawData } from "../types"
+import type { Fields, RawData } from "../types"
 
 export enum StepType {
   upload = "upload",
@@ -39,6 +39,8 @@ export type StepState =
   | {
       type: StepType.validateData
       data: any[]
+      // RsiProps.fields + custom fields
+      fields?: Fields<string>
     }
 
 interface Props {
@@ -148,13 +150,14 @@ export const UploadFlow = ({ nextStep }: Props) => {
         <MatchColumnsStep
           data={state.data}
           headerValues={state.headerValues}
-          onContinue={async (values, rawData, columns) => {
+          onContinue={async (values, rawData, columns, fields) => {
             try {
               const data = await matchColumnsStepHook(values, rawData, columns)
               const dataWithMeta = await addErrorsAndRunHooks(data, fields, rowHook, tableHook)
               setState({
                 type: StepType.validateData,
                 data: dataWithMeta,
+                fields,
               })
               nextStep()
             } catch (e) {
@@ -164,7 +167,13 @@ export const UploadFlow = ({ nextStep }: Props) => {
         />
       )
     case StepType.validateData:
-      return <ValidationStep initialData={state.data} file={uploadedFile!} />
+      return (
+        <ValidationStep
+          initialData={state.data}
+          file={uploadedFile!}
+          fields={(state.fields || fields) as Fields<string>}
+        />
+      )
     default:
       return <Progress isIndeterminate />
   }

--- a/src/steps/ValidationStep/ValidationStep.tsx
+++ b/src/steps/ValidationStep/ValidationStep.tsx
@@ -7,17 +7,20 @@ import { addErrorsAndRunHooks } from "./utils/dataMutations"
 import { generateColumns } from "./components/columns"
 import { Table } from "../../components/Table"
 import { SubmitDataAlert } from "../../components/Alerts/SubmitDataAlert"
-import type { Data } from "../../types"
+import type { Data, Fields } from "../../types"
 import type { themeOverrides } from "../../theme"
 import type { RowsChangeData } from "react-data-grid"
 
 type Props<T extends string> = {
+  fields?: Fields<T>
   initialData: (Data<T> & Meta)[]
   file: File
 }
 
-export const ValidationStep = <T extends string>({ initialData, file }: Props<T>) => {
-  const { translations, fields, onClose, onSubmit, rowHook, tableHook } = useRsi<T>()
+export const ValidationStep = <T extends string>({ initialData, file, fields: mergedFields }: Props<T>) => {
+  const { translations, onClose, onSubmit, rowHook, tableHook, fields: originalFields } = useRsi<T>()
+  // override original fields with fields from props
+  const fields = mergedFields ?? originalFields
   const styles = useStyleConfig(
     "ValidationStep",
   ) as (typeof themeOverrides)["components"]["ValidationStep"]["baseStyle"]

--- a/src/stories/mockRsiValues.ts
+++ b/src/stories/mockRsiValues.ts
@@ -92,6 +92,27 @@ export const mockRsiValues = mockComponentBehaviourForTypes({
   },
   isOpen: true,
   onClose: () => {},
+  customFieldsHook: (c) => {
+    return [
+      {
+        dropDownLabel: `(+)CF boolean`,
+        key: `${c.header} - key boolean`,
+        label: `${c.header} - label`,
+        fieldType: {
+          type: "checkbox",
+        },
+      },
+      {
+        dropDownLabel: `(+)CF string`,
+        key: `${c.header} - key string`,
+        label: `${c.header} - label`,
+        fieldType: {
+          type: "input",
+        },
+        alternateMatches: c.header === "custom_f_F2" ? ["custom_f_F2"] : undefined,
+      },
+    ]
+  },
   // uploadStepHook: async (data) => {
   //   await new Promise((resolve) => {
   //     setTimeout(() => resolve(data), 4000)

--- a/src/stories/mockRsiValues.ts
+++ b/src/stories/mockRsiValues.ts
@@ -109,7 +109,8 @@ export const mockRsiValues = mockComponentBehaviourForTypes({
         fieldType: {
           type: "input",
         },
-        alternateMatches: c.header === "custom_f_F2" ? ["custom_f_F2"] : undefined,
+        // ability to automatically map custom fields
+        alternateMatches: c.header.includes("custom") ? [c.header] : undefined,
       },
     ]
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 import type { Meta } from "./steps/ValidationStep/types"
 import type { DeepReadonly } from "ts-essentials"
 import type { TranslationsRSIProps } from "./translationsRSIProps"
-import type { Columns } from "./steps/MatchColumnsStep/MatchColumnsStep"
+import type { Columns, Column } from "./steps/MatchColumnsStep/MatchColumnsStep"
 import type { StepState } from "./steps/UploadFlow"
 
 export type RsiProps<T extends string> = {
@@ -11,6 +11,9 @@ export type RsiProps<T extends string> = {
   onClose: () => void
   // Field description for requested data
   fields: Fields<T>
+  // Runs on Match Columns step for each column when their state did change.
+  // Used to define custom fields with keys that are can be generated only from csv column header.
+  customFieldsHook?: CustomFieldsHook
   // Runs after file upload step, receives and returns raw sheet data
   uploadStepHook?: (data: RawData[]) => Promise<RawData[]>
   // Runs after header selection step, receives and returns raw sheet data
@@ -59,6 +62,8 @@ export type Fields<T extends string> = DeepReadonly<Field<T>[]>
 export type Field<T extends string> = {
   // UI-facing field label
   label: string
+  // UI-facing label for dropdown option
+  dropDownLabel?: string
   // Field's unique identifier
   key: T
   // UI-facing additional information displayed via tooltip and ? icon
@@ -128,6 +133,7 @@ export type TableHook<T extends string> = (
   table: Data<T>[],
   addError: (rowIndex: number, fieldKey: T, error: Info) => void,
 ) => Data<T>[] | Promise<Data<T>[]>
+export type CustomFieldsHook = (column: Column<string>) => Field<string>[]
 
 export type ErrorLevel = "info" | "warning" | "error"
 


### PR DESCRIPTION
[Free-form "custom" fields? #83 Follow-up #202](https://github.com/UgnisSoftware/react-spreadsheet-import/issues/202)


### Goal: add ability to create new fields in runtime from unmapped csv columns

<img width="752" alt="Screenshot 2023-11-14 at 14 34 55" src="https://github.com/UgnisSoftware/react-spreadsheet-import/assets/17003291/6ac275a1-04c4-4db3-a529-cafba127da82">


* add customFieldsHook into RsiProps: Runs on Match Columns step for each column when their state did change. Used to define custom fields with keys that are can be generated only from csv column header.
* implement customFieldsHook logic
* add dropDownLabel into Field - UI-facing label for dropdown option

<img width="1318" alt="Screenshot 2023-11-14 at 14 28 39" src="https://github.com/UgnisSoftware/react-spreadsheet-import/assets/17003291/19ecd463-6e71-4b15-ba26-c359d1ba291e">

Yes, this logic can be implemented by matchColumnsStepHook but, but in this case user has poor UX:
- can't change column's state from matched to unmatched to mark column as custom field for matchColumnsStepHook
- hard to implement

Yes, this logic can be implemented by selectHeaderStepHook (use local state for fields and update them here)
- but in this case all unknown headers will be displayed on each dropdown list in  Match Columns Step. 

