### PR TITLE
Add scheme to choose when to use rowHook or tableHook

### DIFF
--- a/src/steps/UploadFlow.tsx
+++ b/src/steps/UploadFlow.tsx
@@ -57,6 +57,7 @@ export const UploadFlow = ({ state, onNext, onBack }: Props) => {
     fields,
     rowHook,
     tableHook,
+    runTableHookThreshold,
   } = useRsi()
   const [uploadedFile, setUploadedFile] = useState<File | null>(null)
   const toast = useToast()
@@ -150,7 +151,7 @@ export const UploadFlow = ({ state, onNext, onBack }: Props) => {
           onContinue={async (values, rawData, columns) => {
             try {
               const data = await matchColumnsStepHook(values, rawData, columns)
-              const dataWithMeta = await addErrorsAndRunHooks(data, fields, rowHook, tableHook)
+              const dataWithMeta = await addErrorsAndRunHooks(data, fields, rowHook, tableHook, runTableHookThreshold)
               onNext({
                 type: StepType.validateData,
                 data: dataWithMeta,

--- a/src/steps/ValidationStep/ValidationStep.tsx
+++ b/src/steps/ValidationStep/ValidationStep.tsx
@@ -18,7 +18,7 @@ type Props<T extends string> = {
 }
 
 export const ValidationStep = <T extends string>({ initialData, file, onBack }: Props<T>) => {
-  const { translations, fields, onClose, onSubmit, rowHook, tableHook } = useRsi<T>()
+  const { translations, fields, onClose, onSubmit, rowHook, tableHook, runTableHookThreshold } = useRsi<T>()
   const styles = useStyleConfig(
     "ValidationStep",
   ) as (typeof themeOverrides)["components"]["ValidationStep"]["baseStyle"]
@@ -37,7 +37,7 @@ export const ValidationStep = <T extends string>({ initialData, file, onBack }: 
       if (rowHook?.constructor.name === "AsyncFunction" || tableHook?.constructor.name === "AsyncFunction") {
         setData(rows)
       }
-      addErrorsAndRunHooks<T>(rows, fields, rowHook, tableHook, indexes).then((data) => setData(data))
+      addErrorsAndRunHooks<T>(rows, fields, rowHook, tableHook, runTableHookThreshold, indexes).then((data) => setData(data))
     },
     [rowHook, tableHook, fields],
   )

--- a/src/steps/ValidationStep/tests/ValidationStep.test.tsx
+++ b/src/steps/ValidationStep/tests/ValidationStep.test.tsx
@@ -953,4 +953,79 @@ describe("Validation step tests", () => {
 
     await expect(await screen.findAllByRole("row")).toHaveLength(2)
   })
+  test("Only the table hook is run when enough rows are changed", async () => {
+    const fields = [
+      {
+        label: "Name",
+        key: "name",
+        fieldType: {
+          type: "input",
+        },
+      },
+    ] as const
+    let rowHookCalled = false, tableHookCalled = false
+    const rowHook: RowHook<fieldKeys<typeof fields>> = (data, setError) => {
+      rowHookCalled = true
+      return data
+    }
+    const tableHook: TableHook<fieldKeys<typeof fields>> = (data, setError) => {
+      tableHookCalled = true
+      return data
+    }
+    const runTableHookThreshold = 1
+    addErrorsAndRunHooks(
+      [
+        {
+          name: "First",
+        },
+        {
+          name: "Second",
+        },
+      ],
+      fields,
+      rowHook,
+      tableHook,
+      runTableHookThreshold,
+    )
+    expect(rowHookCalled).toBeFalsy()
+    expect(tableHookCalled).toBeTruthy()
+  })
+  test("Only the row hook is run when too few rows are changed", async () => {
+    const fields = [
+      {
+        label: "Name",
+        key: "name",
+        fieldType: {
+          type: "input",
+        },
+      },
+    ] as const
+    let rowHookCalled = false, tableHookCalled = false
+    const rowHook: RowHook<fieldKeys<typeof fields>> = (data, setError) => {
+      rowHookCalled = true
+      return data
+    }
+    const tableHook: TableHook<fieldKeys<typeof fields>> = (data, setError) => {
+      tableHookCalled = true
+      return data
+    }
+    const runTableHookThreshold = 10
+    addErrorsAndRunHooks(
+      [
+        {
+          name: "First",
+        },
+        {
+          name: "Second",
+        },
+      ],
+      fields,
+      rowHook,
+      tableHook,
+      runTableHookThreshold,
+      [0, 1]
+    )
+    expect(rowHookCalled).toBeTruthy()
+    expect(tableHookCalled).toBeFalsy()
+  })
 })

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,8 @@ export type RsiProps<T extends string> = {
   parseRaw?: boolean
   // Use for right-to-left (RTL) support
   rtl?: boolean
+  // When both rowHook and tableHook are set, it decides when to run a full tableHook depending on the number of changed rows
+  runTableHookThreshold?: number
 }
 
 export type RawData = Array<string | undefined>


### PR DESCRIPTION
Add scheme to choose when to use rowHook or tableHook, depending on which was provided and how many rows have changed.

Logic:
- if neither of `rowHook` or `tableHook` are defined, then proceed
- if only one of `rowHook` or `tableHook` are defined, then use the one that is defined
- if both `rowHook` or `tableHook` are defined, then:
  - inspect `runTableHookThreshold` and set it to 0 if it is not defined
  - if `changedRowIndexes` is undefined or greater than the threshold, then use `tableHook` else use `rowHook`